### PR TITLE
Feature/4 gitlog entry parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# IDE files
+.idea/
+
+# Mac os
+.DS_Store

--- a/author.go
+++ b/author.go
@@ -1,0 +1,14 @@
+package gitlog
+
+import "strings"
+
+// Author - The person which created the commit
+type Author struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+func (t *Author) TrimEmailChars() string {
+	res := strings.TrimPrefix(t.Email, "<")
+	return strings.TrimSuffix(res, ">")
+}

--- a/author_test.go
+++ b/author_test.go
@@ -1,0 +1,14 @@
+package gitlog
+
+import "testing"
+
+func TestAuthor_TrimEmailChars(t *testing.T) {
+	author := &Author{
+		Name:  "mauleyzaola",
+		Email: "<mauricio.leyzaola@gmail.com>",
+	}
+	author.Email = author.TrimEmailChars()
+	if expected, actual := "mauricio.leyzaola@gmail.com", author.Email; expected != actual {
+		t.Errorf("expected:%v actual:%v", expected, actual)
+	}
+}

--- a/commit.go
+++ b/commit.go
@@ -1,0 +1,11 @@
+package gitlog
+
+import "time"
+
+// Commit - Type that holds the information about one single commit
+type Commit struct {
+	Hash    string    `json:"hash"`
+	Author  *Author   `json:"author"`
+	Date    time.Time `json:"date"` // for the sake of simplicity we deal only with AuthorDate
+	Comment string    `json:"comment"`
+}

--- a/parsers.go
+++ b/parsers.go
@@ -26,7 +26,6 @@ func ParseCommitLines(reader io.Reader) ([]Commit, error) {
 				result = append(result, *curr)
 				curr = nil
 			}
-			continue
 		}
 	}
 	if curr != nil {

--- a/parsers.go
+++ b/parsers.go
@@ -1,0 +1,67 @@
+package gitlog
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"time"
+)
+
+// ParseLinesToCommit - Tries to convert a lines of text into a slice of Commits
+// If the format is not a valid one, an error is returned
+func ParseLinesToCommits(reader io.Reader) ([]Commit, error) {
+	scanner := bufio.NewScanner(reader)
+	var (
+		result []Commit
+		curr   *Commit
+	)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if curr == nil {
+			curr = &Commit{}
+		}
+		if ok := curr.ParseLine(line); !ok {
+			continue
+		}
+	}
+	return result, nil
+}
+
+// ParseLine - returns true if the line value affects any field
+func (t *Commit) ParseLine(line string) bool {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return false
+	}
+	switch strings.ToLower(fields[0]) {
+	case "commit":
+		if len(fields) == 2 {
+			t.Hash = fields[1]
+			return true
+		}
+	case "author:":
+		if len(fields) == 3 {
+			author := &Author{
+				Name:  fields[1],
+				Email: fields[2],
+			}
+			author.Email = author.TrimEmailChars()
+			t.Author = author
+			return true
+		}
+	case "authordate:":
+		if len(fields) == 2 {
+			value, err := time.Parse(time.RFC3339, fields[1])
+			if err != nil {
+				return false
+			}
+			t.Date = value
+			return true
+		}
+
+	default:
+		t.Comment = line
+		return true
+	}
+	return false
+}

--- a/parsers_test.go
+++ b/parsers_test.go
@@ -1,0 +1,100 @@
+package gitlog
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+func TestParseLinesToCommit(t *testing.T) {
+	t.Skip()
+	source := `
+commit a77118ea8128202aab725841b44f919c889d949f
+Author:     mauleyzaola <mauricio.leyzaola@gmail.com>
+AuthorDate: 2018-08-26T01:04:55-05:00
+Commit:     mauleyzaola <mauricio.leyzaola@gmail.com>
+CommitDate: 2018-08-26T01:04:55-05:00
+
+    added docker build to update chain
+`
+	buffer := bytes.NewBufferString(source)
+	result, err := ParseLinesToCommits(buffer)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if expected, actual := 1, len(result); expected != actual {
+		t.Errorf("expected:%v actual:%v", expected, actual)
+	}
+}
+
+func TestCommit_ParseLine(t *testing.T) {
+	t.Run("author", commitParseLineAuthor)
+	t.Run("author date", commit_parseLine5)
+	t.Run("commit hash", commit_parseLineHash)
+	t.Run("blank", commit_parseLineBlank)
+	t.Run("comment", commit_parseLineComment)
+}
+
+func commitParseLineAuthor(t *testing.T) {
+	c := &Commit{}
+	line := "Author:     mauleyzaola <mauricio.leyzaola@gmail.com>"
+	ok := c.ParseLine(line)
+	if expected, actual := true, ok; expected != actual {
+		t.Errorf("expected:%v actual:%v", expected, actual)
+	}
+	if c.Author == nil {
+		t.Error("author is nil")
+		return
+	}
+	if expected, actual := "mauleyzaola", c.Author.Name; expected != actual {
+		t.Errorf("expected:%v actual:%v", expected, actual)
+	}
+	if expected, actual := "mauricio.leyzaola@gmail.com", c.Author.Email; expected != actual {
+		t.Errorf("expected:%v actual:%v", expected, actual)
+	}
+}
+
+func commit_parseLineHash(t *testing.T) {
+	c := &Commit{}
+	line := "commit a77118ea8128202aab725841b44f919c889d949f"
+	ok := c.ParseLine(line)
+	if expected, actual := true, ok; expected != actual {
+		t.Errorf("expected:%v actual:%v", expected, actual)
+	}
+	if expected, actual := "a77118ea8128202aab725841b44f919c889d949f", c.Hash; expected != actual {
+		t.Errorf("expected:%v actual:%v", expected, actual)
+	}
+}
+
+func commit_parseLine5(t *testing.T) {
+	c := &Commit{}
+	line := "AuthorDate: 2018-08-26T01:04:55-05:00"
+	ok := c.ParseLine(line)
+	if expected, actual := true, ok; expected != actual {
+		t.Errorf("expected:%v actual:%v", expected, actual)
+	}
+	if expected, actual := time.Date(2018, 8, 26, 1, 4, 55, 0, time.UTC).Add(time.Hour*5).Unix(), c.Date.Unix(); expected != actual {
+		t.Errorf("expected:%v actual:%v", expected, actual)
+	}
+}
+
+func commit_parseLineBlank(t *testing.T) {
+	c := &Commit{}
+	ok := c.ParseLine("")
+	if expected, actual := false, ok; expected != actual {
+		t.Errorf("expected:%v actual:%v", expected, actual)
+	}
+}
+
+func commit_parseLineComment(t *testing.T) {
+	c := &Commit{}
+	line := "added docker build to update chain"
+	ok := c.ParseLine(line)
+	if expected, actual := true, ok; expected != actual {
+		t.Errorf("expected:%v actual:%v", expected, actual)
+	}
+	if expected, actual := line, c.Comment; expected != actual {
+		t.Errorf("expected:%v actual:%v", expected, actual)
+	}
+}


### PR DESCRIPTION
Fixes #4 

```
gitlog$ go test -v -cover .
=== RUN   TestAuthor_TrimEmailChars
--- PASS: TestAuthor_TrimEmailChars (0.00s)
=== RUN   TestParseCommitLines
=== RUN   TestParseCommitLines/single_commit
=== RUN   TestParseCommitLines/multiple_commits
--- PASS: TestParseCommitLines (0.00s)
    --- PASS: TestParseCommitLines/single_commit (0.00s)
    --- PASS: TestParseCommitLines/multiple_commits (0.00s)
=== RUN   TestCommit_ParseLine
=== RUN   TestCommit_ParseLine/author
=== RUN   TestCommit_ParseLine/author_date
=== RUN   TestCommit_ParseLine/commit_hash
=== RUN   TestCommit_ParseLine/blank
=== RUN   TestCommit_ParseLine/comment
--- PASS: TestCommit_ParseLine (0.00s)
    --- PASS: TestCommit_ParseLine/author (0.00s)
    --- PASS: TestCommit_ParseLine/author_date (0.00s)
    --- PASS: TestCommit_ParseLine/commit_hash (0.00s)
    --- PASS: TestCommit_ParseLine/blank (0.00s)
    --- PASS: TestCommit_ParseLine/comment (0.00s)
PASS
coverage: 94.9% of statements
ok  	github.com/mauleyzaola/gitlog	0.006s	coverage: 94.9% of statements
```